### PR TITLE
improve runtime

### DIFF
--- a/common/Scratchpad.cpp
+++ b/common/Scratchpad.cpp
@@ -10,7 +10,8 @@ Scratchpad::~Scratchpad() {}
 
 void Scratchpad::setScratchpad(std::string baseName,
                                unsigned num_of_bytes,
-                               unsigned wordsize)
+                               unsigned wordsize,
+                               uca_org_t cacti_result)
     // wordsize in bytes
 {
   assert(!partitionExist(baseName));
@@ -22,7 +23,6 @@ void Scratchpad::setScratchpad(std::string baseName,
   occupiedBWPerPartition[baseName] = 0;
   sizePerPartition.push_back(num_of_bytes);
   // set read/write/leak/area per partition
-  uca_org_t cacti_result = cactiWrapper(num_of_bytes, wordsize);
 
   // power in mW, energy in nJ, area in mm2
   readEnergyPerPartition.push_back(cacti_result.power.readOp.dynamic * 1e+9);
@@ -159,125 +159,4 @@ float Scratchpad::getLeakagePower(std::string baseName) {
 float Scratchpad::getArea(std::string baseName) {
   unsigned partition_id = findPartitionID(baseName);
   return areaPerPartition.at(partition_id);
-}
-
-uca_org_t Scratchpad::cactiWrapper(unsigned num_of_bytes, unsigned wordsize) {
-  int cache_size = num_of_bytes;
-  int line_size = wordsize;  // in bytes
-  if (wordsize < 4)          // minimum line size in cacti is 32-bit/4-byte
-    line_size = 4;
-  if (cache_size / line_size < 64)
-    cache_size = line_size * 64;  // minimum scratchpad size: 64 words
-  int associativity = 1;
-  int rw_ports = RW_PORTS;
-  int excl_read_ports = 0;
-  int excl_write_ports = 0;
-  int single_ended_read_ports = 0;
-  int search_ports = 0;
-  int banks = 1;
-  double tech_node = 40;  // in nm
-  //# following three parameters are meaningful only for main memories
-  int page_sz = 0;
-  int burst_length = 8;
-  int pre_width = 8;
-  int output_width = wordsize * 8;
-  //# to model special structure like branch target buffers, directory, etc.
-  //# change the tag size parameter
-  //# if you want cacti to calculate the tagbits, set the tag size to "default"
-  int specific_tag = false;
-  int tag_width = 0;
-  int access_mode = 2;  // 0 normal, 1 seq, 2 fast
-  int cache = 0;        // scratch ram 0 or cache 1
-  int main_mem = 0;
-  // assign weights for CACTI optimizations
-  int obj_func_delay = 0;
-  int obj_func_dynamic_power = 0;
-  int obj_func_leakage_power = 1000000;
-  int obj_func_area = 0;
-  int obj_func_cycle_time = 0;
-  // from CACTI example config...
-  int dev_func_delay = 100;
-  int dev_func_dynamic_power = 1000;
-  int dev_func_leakage_power = 10;
-  int dev_func_area = 100;
-  int dev_func_cycle_time = 100;
-
-  int ed_ed2_none = 2;  // 0 - ED, 1 - ED^2, 2 - use weight and deviate
-  int temp = 300;
-  int wt = 0;  // 0 - default(search across everything), 1 - global, 2 - 5%
-               // delay penalty, 3 - 10%, 4 - 20 %, 5 - 30%, 6 - low-swing
-  int data_arr_ram_cell_tech_flavor_in =
-      0;  // 0(itrs-hp) 1-itrs-lstp(low standby power)
-  int data_arr_peri_global_tech_flavor_in = 0;  // 0(itrs-hp)
-  int tag_arr_ram_cell_tech_flavor_in = 2;      // itrs-hp
-  int tag_arr_peri_global_tech_flavor_in = 2;   // itrs-hp
-  int interconnect_projection_type_in = 1;      // 0 - aggressive, 1 - normal
-  int wire_inside_mat_type_in = 2;   // 2 - global, 0 - local, 1 - semi-global
-  int wire_outside_mat_type_in = 2;  // 2 - global
-  int REPEATERS_IN_HTREE_SEGMENTS_in =
-      1;  // TODO for now only wires with repeaters are supported
-  int VERTICAL_HTREE_WIRES_OVER_THE_ARRAY_in = 0;
-  int BROADCAST_ADDR_DATAIN_OVER_VERTICAL_HTREES_in = 0;
-  int force_wiretype = 1;
-  int wiretype = 30;
-  int force_config = 0;
-  int ndwl = 1;
-  int ndbl = 1;
-  int nspd = 0;
-  int ndcm = 1;
-  int ndsam1 = 0;
-  int ndsam2 = 0;
-  int ecc = 0;
-  return cacti_interface(cache_size,
-                         line_size,
-                         associativity,
-                         rw_ports,
-                         excl_read_ports,
-                         excl_write_ports,
-                         single_ended_read_ports,
-                         search_ports,
-                         banks,
-                         tech_node,  // in nm
-                         output_width,
-                         specific_tag,
-                         tag_width,
-                         access_mode,  // 0 normal, 1 seq, 2 fast
-                         cache,        // scratch ram or cache
-                         main_mem,
-                         obj_func_delay,
-                         obj_func_dynamic_power,
-                         obj_func_leakage_power,
-                         obj_func_area,
-                         obj_func_cycle_time,
-                         dev_func_delay,
-                         dev_func_dynamic_power,
-                         dev_func_leakage_power,
-                         dev_func_area,
-                         dev_func_cycle_time,
-                         ed_ed2_none,
-                         temp,
-                         wt,
-                         data_arr_ram_cell_tech_flavor_in,
-                         data_arr_peri_global_tech_flavor_in,
-                         tag_arr_ram_cell_tech_flavor_in,
-                         tag_arr_peri_global_tech_flavor_in,
-                         interconnect_projection_type_in,
-                         wire_inside_mat_type_in,
-                         wire_outside_mat_type_in,
-                         REPEATERS_IN_HTREE_SEGMENTS_in,
-                         VERTICAL_HTREE_WIRES_OVER_THE_ARRAY_in,
-                         BROADCAST_ADDR_DATAIN_OVER_VERTICAL_HTREES_in,
-                         page_sz,
-                         burst_length,
-                         pre_width,
-                         force_wiretype,
-                         wiretype,
-                         force_config,
-                         ndwl,
-                         ndbl,
-                         nspd,
-                         ndcm,
-                         ndsam1,
-                         ndsam2,
-                         ecc);
 }

--- a/common/Scratchpad.cpp
+++ b/common/Scratchpad.cpp
@@ -10,8 +10,7 @@ Scratchpad::~Scratchpad() {}
 
 void Scratchpad::setScratchpad(std::string baseName,
                                unsigned num_of_bytes,
-                               unsigned wordsize,
-                               uca_org_t cacti_result)
+                               unsigned wordsize)
     // wordsize in bytes
 {
   assert(!partitionExist(baseName));
@@ -23,7 +22,15 @@ void Scratchpad::setScratchpad(std::string baseName,
   occupiedBWPerPartition[baseName] = 0;
   sizePerPartition.push_back(num_of_bytes);
   // set read/write/leak/area per partition
-
+  uca_org_t cacti_result;
+  auto cacti_it = cacti_value.find(num_of_bytes);
+  if(cacti_it == cacti_value.end())
+  {
+      cacti_result = cactiWrapper(num_of_bytes, wordsize); 
+      cacti_value[num_of_bytes] = cacti_result;
+  }
+  else 
+      cacti_result = cacti_it->second;
   // power in mW, energy in nJ, area in mm2
   readEnergyPerPartition.push_back(cacti_result.power.readOp.dynamic * 1e+9);
   writeEnergyPerPartition.push_back(cacti_result.power.writeOp.dynamic * 1e+9);
@@ -159,4 +166,125 @@ float Scratchpad::getLeakagePower(std::string baseName) {
 float Scratchpad::getArea(std::string baseName) {
   unsigned partition_id = findPartitionID(baseName);
   return areaPerPartition.at(partition_id);
+}
+
+uca_org_t Scratchpad::cactiWrapper(unsigned num_of_bytes, unsigned wordsize)
+{
+  int cache_size = num_of_bytes;
+  int line_size = wordsize; // in bytes
+  if (wordsize < 4 ) //minimum line size in cacti is 32-bit/4-byte
+    line_size = 4;
+  if (cache_size / line_size < 64)
+    cache_size = line_size * 64; //minimum scratchpad size: 64 words
+  int associativity = 1;
+  int rw_ports = RW_PORTS;
+  int excl_read_ports = 0;
+  int excl_write_ports = 0;
+  int single_ended_read_ports = 0;
+  int search_ports = 0;
+  int banks = 1;
+  double tech_node = 45; // in nm
+  //# following three parameters are meaningful only for main memories
+  int page_sz = 0;
+  int burst_length = 8;
+  int pre_width = 8;
+  int output_width = wordsize * 8;
+  //# to model special structure like branch target buffers, directory, etc.
+  //# change the tag size parameter
+  //# if you want cacti to calculate the tagbits, set the tag size to "default"
+  int specific_tag = false;
+  int tag_width = 0;
+  int access_mode = 2; //0 normal, 1 seq, 2 fast
+  int cache = 0; //scratch ram 0 or cache 1
+  int main_mem = 0;
+  //assign weights for CACTI optimizations
+  int obj_func_delay = 0;
+  int obj_func_dynamic_power = 0;
+  int obj_func_leakage_power = 1000000;
+  int obj_func_area = 0;
+  int obj_func_cycle_time = 0;
+  //from CACTI example config...
+  int dev_func_delay = 100;
+  int dev_func_dynamic_power = 1000;
+  int dev_func_leakage_power = 10;
+  int dev_func_area = 100;
+  int dev_func_cycle_time = 100;
+
+  int ed_ed2_none = 2; // 0 - ED, 1 - ED^2, 2 - use weight and deviate
+  int temp = 300;
+  int wt = 0; //0 - default(search across everything), 1 - global, 2 - 5% delay penalty, 3 - 10%, 4 - 20 %, 5 - 30%, 6 - low-swing
+  int data_arr_ram_cell_tech_flavor_in = 0;  // 0(itrs-hp) 1-itrs-lstp(low standby power)
+  int data_arr_peri_global_tech_flavor_in = 0; // 0(itrs-hp)
+  int tag_arr_ram_cell_tech_flavor_in = 2; // itrs-hp
+  int tag_arr_peri_global_tech_flavor_in = 2; // itrs-hp
+  int interconnect_projection_type_in = 1; // 0 - aggressive, 1 - normal
+  int wire_inside_mat_type_in = 2; // 2 - global, 0 - local, 1 - semi-global
+  int wire_outside_mat_type_in = 2; // 2 - global
+  int REPEATERS_IN_HTREE_SEGMENTS_in = 1;//TODO for now only wires with repeaters are supported
+  int p_input = 0; //print input parameters
+  int VERTICAL_HTREE_WIRES_OVER_THE_ARRAY_in = 0;
+  int BROADCAST_ADDR_DATAIN_OVER_VERTICAL_HTREES_in = 0;
+  int force_wiretype = 1;
+  int wiretype = 30;
+  int force_config = 0;
+  int ndwl = 1;
+  int ndbl = 1;
+  int nspd = 0;
+  int ndcm = 1;
+  int ndsam1 = 0;
+  int ndsam2 = 0;
+  int ecc = 0;
+  return cacti_interface(
+      cache_size,
+      line_size,
+      associativity,
+      rw_ports,
+      excl_read_ports,
+      excl_write_ports,
+      single_ended_read_ports,
+      search_ports,
+      banks,
+      tech_node, // in nm
+      output_width,
+      specific_tag,
+      tag_width,
+      access_mode, //0 normal, 1 seq, 2 fast
+      cache, //scratch ram or cache
+      main_mem,
+      obj_func_delay,
+      obj_func_dynamic_power,
+      obj_func_leakage_power,
+      obj_func_area,
+      obj_func_cycle_time,
+      dev_func_delay,
+      dev_func_dynamic_power,
+      dev_func_leakage_power,
+      dev_func_area,
+      dev_func_cycle_time,
+      ed_ed2_none,
+      temp,
+      wt,
+      data_arr_ram_cell_tech_flavor_in,
+      data_arr_peri_global_tech_flavor_in,
+      tag_arr_ram_cell_tech_flavor_in,
+      tag_arr_peri_global_tech_flavor_in,
+      interconnect_projection_type_in,
+      wire_inside_mat_type_in,
+      wire_outside_mat_type_in,
+      REPEATERS_IN_HTREE_SEGMENTS_in,
+      VERTICAL_HTREE_WIRES_OVER_THE_ARRAY_in,
+      BROADCAST_ADDR_DATAIN_OVER_VERTICAL_HTREES_in,
+      page_sz,
+      burst_length,
+      pre_width,
+      force_wiretype,
+      wiretype ,
+      force_config,
+      ndwl,
+      ndbl,
+      nspd,
+      ndcm,
+      ndsam1,
+      ndsam2,
+      ecc);
 }

--- a/common/Scratchpad.h
+++ b/common/Scratchpad.h
@@ -19,7 +19,8 @@ class Scratchpad {
   void step();
   void setScratchpad(std::string baseName,
                      unsigned num_of_bytes,
-                     unsigned wordsize);
+                     unsigned wordsize,
+                     uca_org_t cacti_result);
   bool canService();
   bool canServicePartition(std::string baseName);
   bool partitionExist(std::string baseName);
@@ -44,8 +45,6 @@ class Scratchpad {
   float getLeakagePower(std::string baseName);
   float getArea(std::string baseName);
 
-  /* Access cacti_interface() to calculate power/area. */
-  uca_org_t cactiWrapper(unsigned num_of_bytes, unsigned wordsize);
 
  private:
   unsigned numOfPartitions;

--- a/common/ScratchpadDatapath.cpp
+++ b/common/ScratchpadDatapath.cpp
@@ -101,17 +101,28 @@ void ScratchpadDatapath::scratchpadPartition() {
   std::unordered_map<unsigned, MemAccess> address;
   initAddress(address);
   // set scratchpad
+  std::unordered_map<unsigned, uca_org_t> cacti_value;
+  std::unordered_map<unsigned, uca_org_t>::iterator cacti_it;
   for (auto it = part_config.begin(); it != part_config.end(); ++it) {
     std::string base_addr = it->first;
     unsigned size = it->second.array_size;  // num of bytes
     unsigned p_factor = it->second.part_factor;
     unsigned wordsize = it->second.wordsize;  // in bytes
     unsigned per_size = ceil(((float)size) / p_factor);
-
+    
+    uca_org_t cacti_result;
+    cacti_it = cacti_value.find(per_size);
+    if(cacti_it == cacti_value.end())
+    {
+        cacti_result = cactiWrapper(per_size, wordsize);  
+        cacti_value[per_size] = cacti_result;
+    }
+    else 
+        cacti_result = cacti_it->second;
     for (unsigned i = 0; i < p_factor; i++) {
       ostringstream oss;
       oss << base_addr << "-" << i;
-      scratchpad->setScratchpad(oss.str(), per_size, wordsize);
+      scratchpad->setScratchpad(oss.str(), per_size, wordsize, cacti_result);
     }
   }
 
@@ -300,4 +311,124 @@ void ScratchpadDatapath::getAverageMemPower(unsigned int cycles,
                                             float* avg_dynamic,
                                             float* avg_leak) {
   scratchpad->getAveragePower(cycles, avg_power, avg_dynamic, avg_leak);
+}
+uca_org_t ScratchpadDatapath::cactiWrapper(unsigned num_of_bytes, unsigned wordsize) {
+  int cache_size = num_of_bytes;
+  int line_size = wordsize;  // in bytes
+  if (wordsize < 4)          // minimum line size in cacti is 32-bit/4-byte
+    line_size = 4;
+  if (cache_size / line_size < 64)
+    cache_size = line_size * 64;  // minimum scratchpad size: 64 words
+  int associativity = 1;
+  int rw_ports = RW_PORTS;
+  int excl_read_ports = 0;
+  int excl_write_ports = 0;
+  int single_ended_read_ports = 0;
+  int search_ports = 0;
+  int banks = 1;
+  double tech_node = 40;  // in nm
+  //# following three parameters are meaningful only for main memories
+  int page_sz = 0;
+  int burst_length = 8;
+  int pre_width = 8;
+  int output_width = wordsize * 8;
+  //# to model special structure like branch target buffers, directory, etc.
+  //# change the tag size parameter
+  //# if you want cacti to calculate the tagbits, set the tag size to "default"
+  int specific_tag = false;
+  int tag_width = 0;
+  int access_mode = 2;  // 0 normal, 1 seq, 2 fast
+  int cache = 0;        // scratch ram 0 or cache 1
+  int main_mem = 0;
+  // assign weights for CACTI optimizations
+  int obj_func_delay = 0;
+  int obj_func_dynamic_power = 0;
+  int obj_func_leakage_power = 1000000;
+  int obj_func_area = 0;
+  int obj_func_cycle_time = 0;
+  // from CACTI example config...
+  int dev_func_delay = 100;
+  int dev_func_dynamic_power = 1000;
+  int dev_func_leakage_power = 10;
+  int dev_func_area = 100;
+  int dev_func_cycle_time = 100;
+
+  int ed_ed2_none = 2;  // 0 - ED, 1 - ED^2, 2 - use weight and deviate
+  int temp = 300;
+  int wt = 0;  // 0 - default(search across everything), 1 - global, 2 - 5%
+               // delay penalty, 3 - 10%, 4 - 20 %, 5 - 30%, 6 - low-swing
+  int data_arr_ram_cell_tech_flavor_in =
+      0;  // 0(itrs-hp) 1-itrs-lstp(low standby power)
+  int data_arr_peri_global_tech_flavor_in = 0;  // 0(itrs-hp)
+  int tag_arr_ram_cell_tech_flavor_in = 2;      // itrs-hp
+  int tag_arr_peri_global_tech_flavor_in = 2;   // itrs-hp
+  int interconnect_projection_type_in = 1;      // 0 - aggressive, 1 - normal
+  int wire_inside_mat_type_in = 2;   // 2 - global, 0 - local, 1 - semi-global
+  int wire_outside_mat_type_in = 2;  // 2 - global
+  int REPEATERS_IN_HTREE_SEGMENTS_in =
+      1;  // TODO for now only wires with repeaters are supported
+  int VERTICAL_HTREE_WIRES_OVER_THE_ARRAY_in = 0;
+  int BROADCAST_ADDR_DATAIN_OVER_VERTICAL_HTREES_in = 0;
+  int force_wiretype = 1;
+  int wiretype = 30;
+  int force_config = 0;
+  int ndwl = 1;
+  int ndbl = 1;
+  int nspd = 0;
+  int ndcm = 1;
+  int ndsam1 = 0;
+  int ndsam2 = 0;
+  int ecc = 0;
+  return cacti_interface(cache_size,
+                         line_size,
+                         associativity,
+                         rw_ports,
+                         excl_read_ports,
+                         excl_write_ports,
+                         single_ended_read_ports,
+                         search_ports,
+                         banks,
+                         tech_node,  // in nm
+                         output_width,
+                         specific_tag,
+                         tag_width,
+                         access_mode,  // 0 normal, 1 seq, 2 fast
+                         cache,        // scratch ram or cache
+                         main_mem,
+                         obj_func_delay,
+                         obj_func_dynamic_power,
+                         obj_func_leakage_power,
+                         obj_func_area,
+                         obj_func_cycle_time,
+                         dev_func_delay,
+                         dev_func_dynamic_power,
+                         dev_func_leakage_power,
+                         dev_func_area,
+                         dev_func_cycle_time,
+                         ed_ed2_none,
+                         temp,
+                         wt,
+                         data_arr_ram_cell_tech_flavor_in,
+                         data_arr_peri_global_tech_flavor_in,
+                         tag_arr_ram_cell_tech_flavor_in,
+                         tag_arr_peri_global_tech_flavor_in,
+                         interconnect_projection_type_in,
+                         wire_inside_mat_type_in,
+                         wire_outside_mat_type_in,
+                         REPEATERS_IN_HTREE_SEGMENTS_in,
+                         VERTICAL_HTREE_WIRES_OVER_THE_ARRAY_in,
+                         BROADCAST_ADDR_DATAIN_OVER_VERTICAL_HTREES_in,
+                         page_sz,
+                         burst_length,
+                         pre_width,
+                         force_wiretype,
+                         wiretype,
+                         force_config,
+                         ndwl,
+                         ndbl,
+                         nspd,
+                         ndcm,
+                         ndsam1,
+                         ndsam2,
+                         ecc);
 }

--- a/common/ScratchpadDatapath.h
+++ b/common/ScratchpadDatapath.h
@@ -31,6 +31,8 @@ class ScratchpadDatapath : public BaseDatapath {
                                   float* avg_leak);
   virtual void getMemoryBlocks(std::vector<std::string>& names);
   virtual int rescheduleNodesWhenNeeded();
+  /* Access cacti_interface() to calculate power/area. */
+  uca_org_t cactiWrapper(unsigned num_of_bytes, unsigned wordsize);
 
  protected:
   Scratchpad* scratchpad;


### PR DESCRIPTION
Improve runtime(Avoid calling cacti repeatedly)

It takes long to call cacti to calculate power/area. In order to reduce the redundant calls, I add a map to record the result computed by cacti since we don't need to call cacti repeatedly if the partition size has been computed beforehand.