### PR TITLE
improve runtime

### DIFF
--- a/common/Scratchpad.cpp
+++ b/common/Scratchpad.cpp
@@ -22,8 +22,16 @@ void Scratchpad::setScratchpad(std::string baseName,
   occupiedBWPerPartition[baseName] = 0;
   sizePerPartition.push_back(num_of_bytes);
   // set read/write/leak/area per partition
-  uca_org_t cacti_result = cactiWrapper(num_of_bytes, wordsize);
 
+  uca_org_t cacti_result;
+  auto cacti_it = cacti_value.find(num_of_bytes);
+  if(cacti_it == cacti_value.end())
+  {
+      cacti_result = cactiWrapper(num_of_bytes, wordsize); 
+      cacti_value[num_of_bytes] = cacti_result;
+  }
+  else 
+      cacti_result = cacti_it->second;
   // power in mW, energy in nJ, area in mm2
   readEnergyPerPartition.push_back(cacti_result.power.readOp.dynamic * 1e+9);
   writeEnergyPerPartition.push_back(cacti_result.power.writeOp.dynamic * 1e+9);

--- a/common/Scratchpad.cpp
+++ b/common/Scratchpad.cpp
@@ -23,13 +23,13 @@ void Scratchpad::setScratchpad(std::string baseName,
   sizePerPartition.push_back(num_of_bytes);
   // set read/write/leak/area per partition
 
-  key cacti_key = std::make_pair(num_of_bytes, wordsize);
+  cacti_key _cacti_key = std::make_pair(num_of_bytes, wordsize);
   uca_org_t cacti_result;
-  auto cacti_it = cacti_value.find(cacti_key);
+  auto cacti_it = cacti_value.find(_cacti_key);
   if(cacti_it == cacti_value.end())
   {
       cacti_result = cactiWrapper(num_of_bytes, wordsize); 
-      cacti_value[cacti_key] = cacti_result;
+      cacti_value[_cacti_key] = cacti_result;
   }
   else 
       cacti_result = cacti_it->second;

--- a/common/Scratchpad.cpp
+++ b/common/Scratchpad.cpp
@@ -23,12 +23,13 @@ void Scratchpad::setScratchpad(std::string baseName,
   sizePerPartition.push_back(num_of_bytes);
   // set read/write/leak/area per partition
 
+  key cacti_key = std::make_pair(num_of_bytes, wordsize);
   uca_org_t cacti_result;
-  auto cacti_it = cacti_value.find(num_of_bytes);
+  auto cacti_it = cacti_value.find(cacti_key);
   if(cacti_it == cacti_value.end())
   {
       cacti_result = cactiWrapper(num_of_bytes, wordsize); 
-      cacti_value[num_of_bytes] = cacti_result;
+      cacti_value[cacti_key] = cacti_result;
   }
   else 
       cacti_result = cacti_it->second;

--- a/common/Scratchpad.h
+++ b/common/Scratchpad.h
@@ -58,6 +58,7 @@ class Scratchpad {
   std::map<std::string, unsigned> partition_loads;
   /* Number of stores per partition. */
   std::map<std::string, unsigned> partition_stores;
+  std::unordered_map<unsigned, uca_org_t> cacti_value;
 
   std::vector<bool> compPartition;
   std::vector<unsigned> sizePerPartition;

--- a/common/Scratchpad.h
+++ b/common/Scratchpad.h
@@ -12,7 +12,7 @@
 #include "cacti-p/io.h"
 #include "cacti-p/cacti_interface.h"
 
-typedef std::pair<unsigned, unsigned> key;
+typedef std::pair<unsigned, unsigned> cacti_key;
 class Scratchpad {
  public:
   Scratchpad(unsigned p_ports_per_part, float cycle_time);
@@ -59,7 +59,7 @@ class Scratchpad {
   std::map<std::string, unsigned> partition_loads;
   /* Number of stores per partition. */
   std::map<std::string, unsigned> partition_stores;
-  std::map<key, uca_org_t> cacti_value;
+  std::map<cacti_key, uca_org_t> cacti_value;
 
   std::vector<bool> compPartition;
   std::vector<unsigned> sizePerPartition;

--- a/common/Scratchpad.h
+++ b/common/Scratchpad.h
@@ -12,6 +12,7 @@
 #include "cacti-p/io.h"
 #include "cacti-p/cacti_interface.h"
 
+typedef std::pair<unsigned, unsigned> key;
 class Scratchpad {
  public:
   Scratchpad(unsigned p_ports_per_part, float cycle_time);
@@ -58,7 +59,7 @@ class Scratchpad {
   std::map<std::string, unsigned> partition_loads;
   /* Number of stores per partition. */
   std::map<std::string, unsigned> partition_stores;
-  std::unordered_map<unsigned, uca_org_t> cacti_value;
+  std::map<key, uca_org_t> cacti_value;
 
   std::vector<bool> compPartition;
   std::vector<unsigned> sizePerPartition;


### PR DESCRIPTION
Improve runtime(Avoid calling cacti repeatedly)

It takes long to call cacti to calculate power/area. In order to reduce the redundant calls, I add a map to record the result computed by cacti since we don't need to call cacti repeatedly if the partition size has been computed beforehand.