### PR TITLE
Bugfixes to gen_space.py script and readme typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,13 @@ Step-by-step:
    1. Both Aladdin and LLVM-Tracer track regions of interest inside a program. In the
       triad example, we want to analyze the triad kernel instead of the setup
       and initialization work done in main. To tell LLVM-Tracer the functions we are
-      interested, set enviroment variable `WORKLOAD` to be the function names (if you
-      have multiple functions interested, separated by comma):
+      interested in, set enviroment variable `WORKLOAD` to be the function names):
 
     ```
     export WORKLOAD=triad
+    ```
+    (if you have multiple functions you are interested in, separate with commas):
+    ```
     export WORKLOAD=md,md_kernel
     ```
    2. Generate LLVM IR:
@@ -155,7 +157,7 @@ Step-by-step:
      ```
      export TRACER_HOME=/your/path/to/LLVM-Tracer
      opt -S -load=$TRACER_HOME/full-trace/full_trace.so -fulltrace triad.llvm -o triad-opt.llvm
-     llvm-link -o full.llvm triad-opt.llvm $TRACER_HOME/profile-func/tracer_logger.llvm
+     llvm-link -o full.llvm triad-opt.llvm $TRACER_HOME/profile-func/trace_logger.llvm
      ```
 
    4. Generate machine code:

--- a/SHOC/scripts/gen_space.py
+++ b/SHOC/scripts/gen_space.py
@@ -19,17 +19,17 @@ pipe = [0,1]
 #In this case, llvm_coompile.py inside run_aladdin.py only need to run once
 #to generate the dynamic instruction trace
 
-#for f_unroll in unroll:
-  #for f_part in part:
-    #for f_pipe in pipe:
-      #os.system('python run_aladdin.py %s %i %i %i' % (bench, f_part, f_unroll, f_pipe))
 
 benchmarks = ['triad', 'reduction', 'stencil', 'fft', 'md', 'pp_scan', 'bb_gemm']
-ALADDIN_HOME = os.getenv('ALADDIN_HOME')
+ALADDIN_HOME = str(os.getenv('ALADDIN_HOME'))
 
 for bench in benchmarks:
   print bench
 
+  for f_unroll in unroll:
+    for f_part in part:
+      for f_pipe in pipe:
+        os.system('python run_aladdin.py %s %i %i %i 6' % (bench, f_part, f_unroll, f_pipe))
   cycle = []
   total_power = []
   fu_power = []
@@ -40,6 +40,8 @@ for bench in benchmarks:
 
 
   BENCH_HOME = ALADDIN_HOME + '/SHOC/' + bench
+  if not os.path.exists(ALADDIN_HOME + '/SHOC/scripts/data/'):
+    os.makedirs(ALADDIN_HOME + '/SHOC/scripts/data/')
 
   os.chdir(BENCH_HOME + '/sim/')
 
@@ -123,3 +125,4 @@ for bench in benchmarks:
   curr_plot.set_ylabel('MEM Area (uM^2)')
   curr_plot.grid(True)
   plt.savefig(bench + '-cycles-mem-area.pdf')
+  os.chdir(ALADDIN_HOME + '/SHOC/scripts/')


### PR DESCRIPTION
Two changes:
1. edit typos in README.md to be consistent with LLVM-Tracer's readme
2. add some checks and directory changes to the gen_space script so it works out of the box for new users